### PR TITLE
amend pom to point at version of common service that does not have an…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,21 +124,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.integration.common</groupId>
             <artifactId>framework</artifactId>
-            <version>0.0.48</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.integration</groupId>
-                    <artifactId>spring-integration-amqp</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework.amqp</groupId>
-                    <artifactId>spring-rabbit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework.amqp</groupId>
-                    <artifactId>spring-amqp</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>0.0.49</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The pom has been changed in preparation for the census-int-common-service being changed to remove its dependencies on spring-integration-amqp and spring-rabbit. When the census-int-common-service has been changed then it should become version 0.0.49 and then there will be no need for the census-mock-case-api-service to exclude those dependencies from its pom.

Please do not merge this pull request until the census-int-common-service has had its dependencies (on spring-integration-amqp and spring-rabbit) removed and has been merged.