### PR TITLE
CR-757 Add FormType, QuestionnaireType

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.integration.common</groupId>
             <artifactId>census-int-case-api-client</artifactId>
-            <version>0.0.7</version>
+            <version>0.0.8-SNAPSHOT</version>
         </dependency>
         <!-- ONS END -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.integration.common</groupId>
             <artifactId>census-int-case-api-client</artifactId>
-            <version>0.0.8-SNAPSHOT</version>
+            <version>0.0.8</version>
         </dependency>
         <!-- ONS END -->
 

--- a/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/endpoint/CaseServiceMockStub.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/endpoint/CaseServiceMockStub.java
@@ -140,7 +140,7 @@ public final class CaseServiceMockStub implements CTPEndpoint {
         String.format("%010d", new Random().nextInt(Integer.MAX_VALUE)));
     newQuestionnaire.setUac("bk5pkrx5hscrclb7");
     newQuestionnaire.setFormType("H");
-    newQuestionnaire.setQuestionnaireType("1");  
+    newQuestionnaire.setQuestionnaireType("1");
 
     return ResponseEntity.ok(newQuestionnaire);
   }

--- a/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/endpoint/CaseServiceMockStub.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/endpoint/CaseServiceMockStub.java
@@ -139,6 +139,8 @@ public final class CaseServiceMockStub implements CTPEndpoint {
     newQuestionnaire.setQuestionnaireId(
         String.format("%010d", new Random().nextInt(Integer.MAX_VALUE)));
     newQuestionnaire.setUac("bk5pkrx5hscrclb7");
+    newQuestionnaire.setFormType("H");
+    newQuestionnaire.setQuestionnaireType("1");  
 
     return ResponseEntity.ok(newQuestionnaire);
   }


### PR DESCRIPTION
# Motivation and Context
Simple change to add FormType and QuestionnaireType to the response for a request to the mock RM Case service endpoint for the url /cases/{caseId}/qid to get a new questionnaire Id for telephone capture.

# What has changed
Addition of required fields to CaseServiceMockStub for appropriate response. Can be tested running mock case service and using Postman to issue the GET request:
//localhost:8161/cases/03f58cb5-9af4-4d40-9d60-c124c5bddf09/qid
