### PR TITLE
update version of census-int-case-api-client pom dependency and add h…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.integration.common</groupId>
             <artifactId>census-int-case-api-client</artifactId>
-            <version>0.0.8</version>
+            <version>0.0.9</version>
         </dependency>
         <!-- ONS END -->
 

--- a/src/main/resources/cases.yml
+++ b/src/main/resources/cases.yml
@@ -40,7 +40,7 @@ casedata:
        "region": "E",
        "collectionExerciseId": "49871667-117d-4a63-9101-f6a0660f73f6",
        "surveyType": "CENSUS",
-	   "handDelivery": false
+       "handDelivery": false
      },
      {
        "caseRef": "124124",

--- a/src/main/resources/cases.yml
+++ b/src/main/resources/cases.yml
@@ -39,7 +39,8 @@ casedata:
        "caseType": "HH",
        "region": "E",
        "collectionExerciseId": "49871667-117d-4a63-9101-f6a0660f73f6",
-       "surveyType": "CENSUS"
+       "surveyType": "CENSUS",
+	   "handDelivery": false
      },
      {
        "caseRef": "124124",
@@ -80,7 +81,8 @@ casedata:
        "caseType": "HH",
        "region": "E",
        "collectionExerciseId": "49871667-117d-4a63-9101-f6a0660f73f6",
-       "surveyType": "CENSUS"
+       "surveyType": "CENSUS",
+       "handDelivery": false
      },
      {
        "caseRef": "124124",
@@ -108,6 +110,7 @@ casedata:
        "caseType": "HH",
        "region": "E",
        "collectionExerciseId": "49871667-117d-4a63-9101-f6a0660f73f6",
-       "surveyType": "CCS"
+       "surveyType": "CCS",
+       "handDelivery": false
      }
      ]'


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This  change is required because RM are adding a new field to their case api service this sprint (starting 11/2/20)

The new field name in RM Case API response is 'handDelivery', it is of type boolean.

# How to test?
<!--- Describe in detail how you tested your changes. -->
Test the changes by running the census-mock-case-api-service and checking that the following endpoints return the handDelivery field in their reponses e.g. :

http://localhost:8161/cases/examples
