### PR TITLE
update version of contactcentreserviceapi to 0.0.66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.integration</groupId>
             <artifactId>contactcentreserviceapi</artifactId>
-            <version>0.0.54</version>
+            <version>0.0.66</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
A simple change to the pom, which is to update the version of contactcentreserviceapi to 0.0.66