### PR TITLE
CR-770 Field Service to pass formType to EQ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.integration.common</groupId>
             <artifactId>census-int-case-api-client</artifactId>
-            <version>0.0.10</version>
+            <version>0.0.11</version>
         </dependency>
         <!-- ONS END -->
 

--- a/src/main/resources/questionnaires.yml
+++ b/src/main/resources/questionnaires.yml
@@ -2,14 +2,17 @@ questionnairedata:
   questionnaires: '[
      {
        "questionnaireId": "3305e937-6fb1-4ce1-9d4c-077f147789ab",
-       "active": "true"
+       "active": "true",
+       "formType": "H"
      },
     {
       "questionnaireId": "3305e937-6fb1-4ce1-9d4c-077f147789ac",
-      "active": "true"
+      "active": "true",
+      "formType": "I"
     },
     {
       "questionnaireId": "03f58cb5-9af4-4d40-9d60-c124c5bddf09",
-      "active": "false"
+      "active": "false",
+      "formType": "C"
     }
   ]'


### PR DESCRIPTION
# Motivation and Context
Formtype is hard coded when the Field service calls EQ. It is now to be provided by the RM case-api service and passed to EQ by the Field service launch endpoint. This change to the mock case-api service supplies formType as per RM changes.

# What has changed
Now uses version 0.0.11 of census-int-case-api-client.  GET endpoint to find a QuestionnaireId by CaseId returns amended QuestionnaireIdDTO with formType attribute added.

# How to test?
Running locally can be tested with URL path such as: /cases/ccs/03f58cb5-9af4-4d40-9d60-c124c5bddf09/qid

# Links
https://github.com/ONSdigital/census-int-case-api-client/pull/10
https://github.com/ONSdigital/census-field-service/pull/34