### PR TITLE
CR-1047 Extend UPRN validation to allow 13 digits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,20 +124,20 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.61</version>
+      <version>0.0.62</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>test-framework</artifactId>
-      <version>0.0.14</version>
+      <version>0.0.16</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>product-reference</artifactId>
-      <version>1.0.6</version>
+      <version>1.0.8</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
# Motivation and Context
UPRNs generated for skeleton cases by RM have an additional leading digit, needing to allow for 13 digits.

# What has changed
POM dependencies changed to include new UniquePropertyReferenceNumber allowing for 13 digits. Changed just in case someone requested a case by UPRN with 13 digits expecting a Not Found 404, but would have got a BadRequest 400. Also updated Product Reference to latest version for conformity while here.

# How to test?
Contact centre cucumber tests updated and run against this image in census-integration-dev.

# Links
Framework: https://github.com/ONSdigital/census-int-common-service/pull/44
Contact centre service api: https://github.com/ONSdigital/census-contact-centre-service-api/pull/53
Contact centre cucumber: https://github.com/ONSdigital/census-contact-centre-cucumber/pull/47
https://github.com/ONSdigital/census-contact-centre-service/pull/82
