### PR TITLE
Cr 1121 ad cucumber tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.62</version>
+      <version>0.0.64</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/validation/RequestValidator.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/validation/RequestValidator.java
@@ -1,0 +1,65 @@
+package uk.gov.ons.ctp.integration.mockcaseapiservice.validation;
+
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
+
+/**
+ * Copy of RM RequestValidator
+ *
+ * <pre>
+ * @see <a href="RM RequestValidator">https://github.com/ONSdigital/census-rm-case-api/blob/master/src/main/java/uk/gov/ons/census/caseapisvc/validation/RequestValidator.java</a>
+ * </pre>
+ */
+public class RequestValidator {
+  public static void validateGetNewQidByCaseIdRequest(
+      CaseContainerDTO caze, boolean individual, UUID individualCaseId) {
+    if (caze.getCaseType().equals("HH") && individual && individualCaseId == null) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("HH") && !individual && individualCaseId != null) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("CE")
+        && caze.getAddressLevel().equals("E")
+        && !individual
+        && individualCaseId != null) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("CE")
+        && caze.getAddressLevel().equals("E")
+        && individual
+        && individualCaseId != null) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("CE")
+        && caze.getAddressLevel().equals("U")
+        && individual
+        && individualCaseId == null) {
+      return; // Valid request
+    } else if (caze.getCaseType().equals("CE") && caze.getAddressLevel().equals("U")) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("SPG")
+        && caze.getAddressLevel().equals("E")
+        && !individual
+        && individualCaseId != null) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("SPG")
+        && caze.getAddressLevel().equals("E")
+        && individual
+        && individualCaseId != null) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("SPG")
+        && caze.getAddressLevel().equals("U")
+        && !individual
+        && individualCaseId != null) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("SPG")
+        && caze.getAddressLevel().equals("U")
+        && individual
+        && individualCaseId != null) {
+      throwBadRequest();
+    }
+  }
+
+  private static void throwBadRequest() {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid request");
+  }
+}


### PR DESCRIPTION
# Motivation and Context
Changes to facilitate cucumber testing of CC EQ launch URL and AD endpoint to obtain a UAC. 

# What has changed
Copy of RM case service RequestValidator class used to validate new questionnaire (/{caseId}/qid) requests and random alpha numeric UAC now returned. Endpoint should return new questionnaire Id and UAC.
Also updated to latest common framework dependency.

# How to test?
Tested in integration environment for RH and CC cucumber tests.

# Links
Original endpoint code PR: https://github.com/ONSdigital/census-contact-centre-service/pull/97