### PR TITLE
Cr 1089 create modify endpoint in preparation for cuc tests

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/CasesConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/CasesConfig.java
@@ -99,6 +99,7 @@ public class CasesConfig {
    */
   public void modifyData(final List<CaseContainerDTO> caseList) throws CTPException {
     for (CaseContainerDTO caseDetails : caseList) {
+      checkCaseExists(caseDetails.getId().toString());
       modifyMaps(caseDetails);
     }
   }
@@ -121,6 +122,14 @@ public class CasesConfig {
     synchronized (caseRefMap) {
       caseRefMap.clear();
       setCases(cases);
+    }
+  }
+
+  private void checkCaseExists(String strCaseId) throws CTPException {
+    if (!caseUUIDMap.containsKey(strCaseId)) {
+      throw new CTPException(
+          CTPException.Fault.BAD_REQUEST,
+          "Case cannot be modified as UUID not found: " + strCaseId);
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/CasesConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/CasesConfig.java
@@ -93,6 +93,17 @@ public class CasesConfig {
   }
 
   /**
+   * modify data in the case maps from a list of Cases
+   *
+   * @param caseList - list of cases
+   */
+  public void modifyData(final List<CaseContainerDTO> caseList) throws CTPException {
+    for (CaseContainerDTO caseDetails : caseList) {
+      modifyMaps(caseDetails);
+    }
+  }
+
+  /**
    * Reset the data maps back to the original JSON
    *
    * @throws IOException - thrown
@@ -110,6 +121,28 @@ public class CasesConfig {
     synchronized (caseRefMap) {
       caseRefMap.clear();
       setCases(cases);
+    }
+  }
+
+  private void modifyMaps(CaseContainerDTO caseDetails) {
+    synchronized (caseUUIDMap) {
+      caseUUIDMap.replace(caseDetails.getId().toString(), caseDetails);
+    }
+    synchronized (caseRefMap) {
+      caseRefMap.replace(caseDetails.getCaseRef(), caseDetails);
+    }
+    synchronized (caseUprnMap) {
+      ArrayList casesForUprn;
+      if (!caseUprnMap.containsKey(caseDetails.getUprn())) {
+        caseUprnMap.put(caseDetails.getUprn(), new ArrayList<>());
+      }
+      casesForUprn = (ArrayList) caseUprnMap.get(caseDetails.getUprn());
+      for (int i = 0; i < casesForUprn.size(); i++) {
+        System.out.println("The case found for the uprn " + casesForUprn.get(i));
+      }
+    }
+    synchronized (eventMap) {
+      // eventMap.clear();
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/CasesConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/CasesConfig.java
@@ -132,20 +132,14 @@ public class CasesConfig {
       caseRefMap.replace(caseDetails.getCaseRef(), caseDetails);
     }
     synchronized (caseUprnMap) {
-      ArrayList<CaseContainerDTO> casesForUprn;
-      if (!caseUprnMap.containsKey(caseDetails.getUprn())) {
-        caseUprnMap.put(caseDetails.getUprn(), new ArrayList<>());
-      }
-      casesForUprn = (ArrayList<CaseContainerDTO>) caseUprnMap.get(caseDetails.getUprn());
+      ArrayList<CaseContainerDTO> casesForUprn =
+          (ArrayList<CaseContainerDTO>) caseUprnMap.get(caseDetails.getUprn());
       for (int i = 0; i < casesForUprn.size(); i++) {
-        System.out.println("The case found for the uprn " + casesForUprn.get(i));
         CaseContainerDTO caseFound = casesForUprn.get(i);
         if (caseFound.getId().toString().equals(caseDetails.getId().toString())) {
-          System.out.println("I think we have a match for case number: " + i);
           casesForUprn.set(i, caseDetails);
         }
       }
-      //      caseUprnMap.replace(caseDetails.getUprn(), casesForUprn);
     }
     synchronized (eventMap) {
       // eventMap.clear();

--- a/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/CasesConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/CasesConfig.java
@@ -151,7 +151,7 @@ public class CasesConfig {
       }
     }
     synchronized (eventMap) {
-      // eventMap.clear();
+      eventMap.replace(caseDetails.getId().toString(), caseDetails.getCaseEvents());
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/CasesConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/CasesConfig.java
@@ -132,14 +132,20 @@ public class CasesConfig {
       caseRefMap.replace(caseDetails.getCaseRef(), caseDetails);
     }
     synchronized (caseUprnMap) {
-      ArrayList casesForUprn;
+      ArrayList<CaseContainerDTO> casesForUprn;
       if (!caseUprnMap.containsKey(caseDetails.getUprn())) {
         caseUprnMap.put(caseDetails.getUprn(), new ArrayList<>());
       }
-      casesForUprn = (ArrayList) caseUprnMap.get(caseDetails.getUprn());
+      casesForUprn = (ArrayList<CaseContainerDTO>) caseUprnMap.get(caseDetails.getUprn());
       for (int i = 0; i < casesForUprn.size(); i++) {
         System.out.println("The case found for the uprn " + casesForUprn.get(i));
+        CaseContainerDTO caseFound = casesForUprn.get(i);
+        if (caseFound.getId().toString().equals(caseDetails.getId().toString())) {
+          System.out.println("I think we have a match for case number: " + i);
+          casesForUprn.set(i, caseDetails);
+        }
       }
+      //      caseUprnMap.replace(caseDetails.getUprn(), casesForUprn);
     }
     synchronized (eventMap) {
       // eventMap.clear();

--- a/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/endpoint/CaseServiceMockStub.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/mockcaseapiservice/endpoint/CaseServiceMockStub.java
@@ -250,6 +250,23 @@ public final class CaseServiceMockStub implements CTPEndpoint {
     }
   }
 
+  /**
+   * Post a list of Cases in order to modify those in the case maps driving the responses here.
+   *
+   * @param requestBody - a list of cases
+   * @return - response confirming post.
+   */
+  @RequestMapping(value = "/data/cases/modify", method = RequestMethod.POST)
+  @ResponseStatus(value = HttpStatus.OK)
+  public ResponseEntity<ResponseDTO> modifyCaseData(@RequestBody List<CaseContainerDTO> requestBody)
+      throws CTPException {
+
+    log.with("requestBody", requestBody).info("Entering POST modifyCData");
+    casesConfig.modifyData(requestBody);
+
+    return ResponseEntity.ok(createResponseDTO("MockCaseModifyService"));
+  }
+
   private ResponseDTO createResponseDTO(final String id) {
     final ResponseDTO responseDTO = new ResponseDTO();
     responseDTO.setId(id);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change to the mock case service is required in order to mimic RM in the following scenario:

Given the case does not exist in the cache
And the case exists in RM
When the case address details are modified
And the case modified event is sent to RM and RM <does immediately> action it
When the call is made to fetch the case again from GetCaseByUPRN
Then GetCaseByUPRN gets the modified case from RM

NB. The above scenario has yet to be written - this is a pre-requisite for it.

# What has changed
<!--- What code changes has been made -->
A new POST endpoint has been added to the mock case service, which allows an existing case to be modified. It is works locally with the following URL:

http://localhost:8161/cases/data/cases/modify

It is very similar to the add endpoint; it also requires a request body, which is of type List<CaseContainerDTO>, such as this:

[{
        "caseRef": "123123002",
        "arid": "2344266233",
        "estabArid": "AABBCC",
        "estabType": "ET",
        "uprn": "1347459999",
        "createdDateTime": "2019-04-14T13:45:26.564+01:00",
        "addressLine1": "Happy House Three",
        "addressLine2": "89 Harbour Street",
        "addressLine3": "Somewhere",
        "townName": "Portsmouth",
        "postcode": "G1 2AA",
        "organisationName": "ON",
        "addressLevel": "E",
        "abpCode": "AACC",
        "latitude": "41.40338",
        "longitude": "2.17403",
        "oa": "EE22",
        "lsoa": "x1",
        "msoa": "x2",
        "lad": "H1",
        "caseEvents": [
            {
                "id": "101",
                "eventType": "CASE_UPDATED",
                "description": "Initial creation of case",
                "createdDateTime": "2019-04-14T13:45:26.564+01:00"
            },
            {
                "id": "102",
                "eventType": null,
                "description": "Create Household Visit",
                "createdDateTime": "2019-04-14T13:45:26.564+01:00"
            }
        ],
        "id": "3305e937-6fb1-4ce1-9d4c-077f147789ac",
        "caseType": "HH",
        "addressType": "SPG",
        "region": "E",
        "collectionExerciseId": "49871667-117d-4a63-9101-f6a0660f73f6",
        "surveyType": "CENSUS",
        "handDelivery": false
    }]

<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
Test the changes by firstly running one of the GET case endpoints in Postman e.g.

http://localhost:8161/cases/3305e937-6fb1-4ce1-9d4c-077f147789ac

Then run the modify endpoint in Postman, as described above, and then re-run the GET endpoint to check that the case has been modified.
